### PR TITLE
Set resource limits of the containers

### DIFF
--- a/app/deployment_operator.yaml
+++ b/app/deployment_operator.yaml
@@ -22,6 +22,10 @@ spec:
       - name: prismserver-operator
         image: prismhosting/ocp-csgo-operator:latest
         imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: "1"
+            memory: 2G
         env:
           - name: UNIFI_API_HOST
             valueFrom:


### PR DESCRIPTION
With this the maximum a server can consume is 1 CPU (1000m) and 2GB of ram, that should be enough to run our 12 slot 128 tick servers.